### PR TITLE
Derive Debug for QuoteV4 and fix build on nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0-pre.3 (git+https://github.com/RustCrypto/hashes.git)",
  "sha3",
+ "time",
  "x509-parser",
 ]
 
@@ -425,6 +426,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -713,12 +720,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -733,10 +741,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ x509-parser  = "0.15.1"
 serde        = { version = "1.0", features = ["derive"] }
 serde_json   = "1.0"
 chrono       = "0.4"
+time         = "0.3.36"
 
 p256         = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
 sha2         = { git = "https://github.com/RustCrypto/hashes.git" }

--- a/src/types/quotes/version_4.rs
+++ b/src/types/quotes/version_4.rs
@@ -1,6 +1,7 @@
 use super::{CertData, QuoteHeader, body::*};
 use crate::constants::{ENCLAVE_REPORT_LEN, SGX_TEE_TYPE, TD10_REPORT_LEN, TDX_TEE_TYPE};
 
+#[derive(Clone, Debug)]
 pub struct QuoteV4 {
     pub header: QuoteHeader,            // [48 bytes]
                                         // Header of Quote data structure.


### PR DESCRIPTION
On rust nightly, the time crate fails to build because of the bug listed here: https://github.com/time-rs/time/issues/681 
Hence adding the extra version for the time crate used by one of our dependencies.