### PR TITLE
Remove unused crate `p256_accelerated`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,8 +531,7 @@ dependencies = [
  "alloy-sol-types",
  "chrono",
  "hex",
- "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "p256 0.13.2 (git+https://github.com/automata-network/RustCrypto-elliptic-curves.git)",
+ "p256",
  "serde",
  "serde_json",
  "sha2 0.11.0-pre.3",
@@ -1082,20 +1081,7 @@ checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "primeorder 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "git+https://github.com/automata-network/RustCrypto-elliptic-curves.git#3ae63bd91f4cbac73873a659be84c42a2da4792d"
-dependencies = [
- "cfg-if",
- "ecdsa",
- "elliptic-curve",
- "once_cell",
- "primeorder 0.13.6 (git+https://github.com/automata-network/RustCrypto-elliptic-curves.git)",
+ "primeorder",
  "sha2 0.10.8",
 ]
 
@@ -1181,14 +1167,6 @@ name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "git+https://github.com/automata-network/RustCrypto-elliptic-curves.git#3ae63bd91f4cbac73873a659be84c42a2da4792d"
 dependencies = [
  "elliptic-curve",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,10 @@ serde_json   = "1.0"
 chrono       = "0.4"
 time         = "0.3.36"
 
-p256         = { version = "0.13.2", optional = true }
+p256         = { version = "0.13.2" }
 sha2         = { git = "https://github.com/RustCrypto/hashes.git" }
 sha3         = { git = "https://github.com/RustCrypto/hashes.git" }
 alloy-sol-types = "0.8.12"
 
-[dependencies.p256_accelerated]
-package = "p256"
-git = "https://github.com/automata-network/RustCrypto-elliptic-curves.git"
-optional = true
-
 [features]
-default = ["p256"]
-accelerated = ["p256_accelerated"]
+default = []


### PR DESCRIPTION
Hi there!

I am aware that `p256_accelerated` dependency includes an accelerated implementation for the risc0 zkVM. However, enabling the feature `accelerated` does not seem to reference the accelerated crate within the current implementation.
In my understanding, to apply the accelerator to the p256, users can refer to [the instructions in the README](https://github.com/automata-network/dcap-rs?tab=readme-ov-file#zkvm-patches) and specify [the patch](https://github.com/automata-network/RustCrypto-elliptic-curves) in their crate. Therefore, I believe these configurations can be removed.