### PR TITLE
TcbInfo Object Serialization Update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,8 @@ pub fn verify_dcap_quote(
 
     // 3. Verify the status of Intel SGX TCB described in the chain.
     let pck_extension = quote.signature.get_pck_extension()?;
-    let (sgx_tcb_status, tdx_tcb_status, advisory_ids) = verify_tcb_status(&tcb_info, &pck_extension, &quote)?;
+    let (sgx_tcb_status, tdx_tcb_status, advisory_ids) =
+        verify_tcb_status(&tcb_info, &pck_extension, &quote)?;
 
     assert!(
         sgx_tcb_status != TcbStatus::Revoked || tdx_tcb_status != TcbStatus::Revoked,
@@ -77,8 +78,6 @@ pub fn verify_dcap_quote(
         advisory_ids,
     })
 }
-
-
 
 fn verify_integrity(
     current_time: SystemTime,
@@ -198,7 +197,6 @@ pub fn verify_quote_enclave_source(
     collateral: &Collateral,
     quote: &Quote,
 ) -> anyhow::Result<QeTcbStatus> {
-
     // Verify that the enclave identity root is signed by root certificate
     let qe_identity = collateral
         .qe_identity
@@ -331,7 +329,18 @@ pub fn verify_tcb_status(
     quote: &Quote,
 ) -> anyhow::Result<(TcbStatus, TcbStatus, Vec<String>)> {
     // Make sure the tcb_info matches the enclave's model/PCE version
-    if pck_extension.fmspc != tcb_info.fmspc {
+
+    let tcb_info_fmspc_bytes: [u8; 6] = hex::decode(tcb_info.fmspc.as_str())
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    let tcb_info_pce_id_bytes: [u8; 2] = hex::decode(tcb_info.pce_id.as_str())
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    if pck_extension.fmspc != tcb_info_fmspc_bytes {
         return Err(anyhow::anyhow!(
             "tcb fmspc mismatch (pck extension: {:?}, tcb_info: {:?})",
             pck_extension.fmspc,
@@ -339,7 +348,7 @@ pub fn verify_tcb_status(
         ));
     }
 
-    if pck_extension.pceid != tcb_info.pce_id {
+    if pck_extension.pceid != tcb_info_pce_id_bytes {
         return Err(anyhow::anyhow!(
             "tcb pceid mismatch (pck extension: {:?}, tcb_info: {:?})",
             pck_extension.pceid,

--- a/src/types/tcb_info.rs
+++ b/src/types/tcb_info.rs
@@ -78,7 +78,7 @@ impl TcbInfoAndSignature {
 /// the TcbLevel
 
 #[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
-#[serde(try_from = "u16")]
+#[serde(try_from = "u16", into = "u16")]
 #[borsh(use_discriminant = true)]
 pub enum TcbInfoVersion {
     V2 = 2,
@@ -93,6 +93,12 @@ impl TryFrom<u16> for TcbInfoVersion {
             3 => Ok(TcbInfoVersion::V3),
             _ => Err("Unsupported TCB Info version"),
         }
+    }
+}
+
+impl From<TcbInfoVersion> for u16 {
+    fn from(value: TcbInfoVersion) -> Self {
+        value as u16
     }
 }
 

--- a/src/types/tcb_info.rs
+++ b/src/types/tcb_info.rs
@@ -308,9 +308,13 @@ pub struct TcbV3 {
     pcesvn: u16,
 }
 
-#[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug, Copy, BorshSerialize, BorshDeserialize)]
+#[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct TcbComponentV3 {
     svn: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    tcb_type: Option<String>
 }
 
 
@@ -363,14 +367,28 @@ impl Tcb {
                 v2.sgxtcbcomp15svn,
                 v2.sgxtcbcomp16svn,
             ],
-            Self::V3(v3) => v3.sgxtcbcomponents.map(|comp| comp.svn),
+            Self::V3(v3) => {
+                let mut result = [0u8; 16];
+                for i in 0..16 {
+                    result[i] = v3.sgxtcbcomponents[i].svn;
+                }
+                result
+            },
         }
     }
 
     pub fn tdx_tcb_components(&self) -> Option<[u8; 16]> {
         match self {
             Self::V2(_) => None,
-            Self::V3(v3) => v3.tdxtcbcomponents.map(|components| components.map(|comp| comp.svn)),
+            Self::V3(v3) => {
+                v3.tdxtcbcomponents.as_ref().map(|components| {
+                    let mut result = [0u8; 16];
+                    for i in 0..16 {
+                        result[i] = components[i].svn;
+                    }
+                    result
+                })
+            },
         }
     }
 }

--- a/src/types/tcb_info.rs
+++ b/src/types/tcb_info.rs
@@ -112,12 +112,10 @@ pub struct TcbInfo {
     pub issue_date: chrono::DateTime<Utc>,
     #[borsh(deserialize_with = "borsh_datetime_as_instant::deserialize", serialize_with = "borsh_datetime_as_instant::serialize")]
     pub next_update: chrono::DateTime<Utc>,
-    #[serde(with = "hex")]
-    pub fmspc: [u8; 6],
-    #[serde(with = "hex")]
-    pub pce_id: [u8; 2],
-    pub tcb_type: u16,
-    pub tcb_evaluation_data_number: u16,
+    pub fmspc: String,
+    pub pce_id: String,
+    tcb_type: u16,
+    _tcb_evaluation_data_number: u16,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tdx_module: Option<TdxModule>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/types/tcb_info.rs
+++ b/src/types/tcb_info.rs
@@ -303,9 +303,9 @@ impl Tcb {
 #[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct TcbV3 {
     sgxtcbcomponents: [TcbComponentV3; 16],
+    pcesvn: u16,
     #[serde(skip_serializing_if = "Option::is_none")]
     tdxtcbcomponents: Option<[TcbComponentV3; 16]>,
-    pcesvn: u16,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]

--- a/src/types/tcb_info.rs
+++ b/src/types/tcb_info.rs
@@ -7,7 +7,8 @@ use p256::ecdsa::signature::Verifier;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use borsh::{BorshDeserialize, BorshSerialize};
-use crate::utils::borsh_datetime_as_instant;
+use sha2::{Sha256, Digest};
+use crate::utils::{borsh_datetime_as_instant, HashingWriter};
 
 use super::{quote::{Quote, QuoteBody}, report::Td10ReportBody, sgx_x509::SgxPckExtension};
 
@@ -240,6 +241,25 @@ impl TcbInfo {
     pub fn to_borsh_bytes(&self) -> anyhow::Result<Vec<u8>> {
         borsh::to_vec(self)
             .map_err(|e| anyhow::anyhow!("Failed to serialize TcbInfo: {}", e))
+    }
+
+    /// Compute SHA256 hash of the JSON representation without storing the entire JSON
+    ///
+    /// This method serializes the TcbInfo object incrementally to a hasher,
+    /// minimizing stack and heap usage by avoiding storing the complete JSON string.
+    pub fn compute_json_hash(&self) -> anyhow::Result<[u8; 32]> {
+        let mut hasher = Sha256::new();
+        
+        // Create a writer that feeds directly to the hasher
+        let mut writer = HashingWriter::new(&mut hasher);
+        
+        // Serialize directly to the writer
+        let mut serializer = serde_json::Serializer::new(&mut writer);
+        serde::Serialize::serialize(self, &mut serializer)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize TcbInfo: {}", e))?;
+        
+        // Return the final hash
+        Ok(hasher.finalize().into())
     }
 }
 
@@ -515,6 +535,53 @@ impl TcbStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_incremental_json_hash() {
+        // Load a TcbInfo from a test file
+        let json = include_str!("../../data/tcb_info_v2.json");
+        let tcb_info_and_signature: TcbInfoAndSignature = serde_json::from_str(json).unwrap();
+        let tcb_info = tcb_info_and_signature.get_tcb_info().unwrap();
+        
+        // Compute hash using our incremental method
+        let incremental_hash = tcb_info.compute_json_hash().unwrap();
+        
+        // Compute hash using the traditional method (serialize to string then hash)
+        let json_string = serde_json::to_string(&tcb_info).unwrap();
+        let mut traditional_hasher = Sha256::new();
+        traditional_hasher.update(json_string.as_bytes());
+        let traditional_hash = traditional_hasher.finalize();
+        
+        // The hashes should match
+        assert_eq!(incremental_hash, <[u8; 32]>::from(traditional_hash));
+    }
+    
+    #[test]
+    fn test_borsh_deserialize_and_hash_json() {
+        // Load a TcbInfo from a test file
+        let json = include_str!("../../data/tcb_info_v2.json");
+        let tcb_info_and_signature: TcbInfoAndSignature = serde_json::from_str(json).unwrap();
+        let original_tcb_info = tcb_info_and_signature.get_tcb_info().unwrap();
+        
+        // Serialize to Borsh format
+        let borsh_bytes = borsh::to_vec(&original_tcb_info).unwrap();
+        
+        // Use our incremental method to deserialize and hash
+        let deserialized_tcb_info = TcbInfo::from_borsh_bytes(&borsh_bytes).unwrap();
+        let incremental_hash = deserialized_tcb_info.compute_json_hash().unwrap();
+        
+        // Verify the deserialized object matches the original
+        assert_eq!(original_tcb_info, deserialized_tcb_info);
+        
+        // Compute hash using the traditional method for comparison
+        let json_string = serde_json::to_string(&original_tcb_info).unwrap();
+        let mut traditional_hasher = Sha256::new();
+        traditional_hasher.update(json_string.as_bytes());
+        let traditional_hash = traditional_hasher.finalize();
+        
+        // The hashes should match
+        assert_eq!(incremental_hash, <[u8; 32]>::from(traditional_hash));
+    }
 
     #[test]
     fn test_parsing_tcb_info_without_tdx_module() {

--- a/src/types/tcb_info.rs
+++ b/src/types/tcb_info.rs
@@ -158,14 +158,18 @@ impl TcbInfo {
             (&tdx_module.mrsigner, &tdx_module.attributes)
         };
 
+        // Convert mrsigner and attributes to the appropriate type
+        let mrsigner_bytes: [u8; 48] = hex::decode(mrsigner).unwrap().try_into().unwrap();
+        let attributes_bytes: [u8; 8] = hex::decode(attributes).unwrap().try_into().unwrap();
+
         // Check for mismatches with a single validation
-        if mrsigner != &quote_body.mr_signer_seam {
+        if mrsigner_bytes != quote_body.mr_signer_seam {
             return Err(anyhow::anyhow!(
                 "mrsigner mismatch between tdx module identity and tdx quote body"
             ));
         }
 
-        if attributes != &quote_body.seam_attributes {
+        if attributes_bytes != quote_body.seam_attributes {
             return Err(anyhow::anyhow!(
                 "attributes mismatch between tdx module identity and tdx quote body"
             ));
@@ -374,12 +378,10 @@ impl Tcb {
 #[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TdxModule {
-    #[serde(with = "hex", rename = "mrsigner")]
-    mrsigner: [u8; 48],
-    #[serde(with = "hex")]
-    attributes: [u8; 8],
-    #[serde(with = "hex")]
-    attributes_mask: [u8; 8],
+    #[serde(rename = "mrsigner")]
+    mrsigner: String,
+    attributes: String,
+    attributes_mask: String,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
@@ -387,12 +389,10 @@ pub struct TdxModule {
 pub struct TdxModuleIdentity {
     #[serde(rename = "id")]
     id: String,
-    #[serde(with = "hex", rename = "mrsigner")]
-    mrsigner: [u8; 48],
-    #[serde(with = "hex")]
-    attributes: [u8; 8],
-    #[serde(with = "hex")]
-    attributes_mask: [u8; 8],
+    #[serde(rename = "mrsigner")]
+    mrsigner: String,
+    attributes: String,
+    attributes_mask: String,
     tcb_levels: Vec<TdxTcbLevel>,
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use std::time::SystemTime;
+use std::io::Write;
 
 use x509_cert::{certificate::CertificateInner, crl::CertificateList};
 
@@ -304,4 +305,28 @@ pub fn read_bytes<'a>(bytes: &mut &'a [u8], size: usize) -> &'a [u8] {
     let (front, rest) = bytes.split_at(size);
     *bytes = rest;
     front
+}
+
+/// A writer that updates a hasher as it receives data
+/// 
+/// This is used for incremental serialization and hashing to minimize memory usage.
+pub struct HashingWriter<'a, H> {
+    hasher: &'a mut H,
+}
+
+impl<'a, H: sha2::Digest> HashingWriter<'a, H> {
+    pub fn new(hasher: &'a mut H) -> Self {
+        Self { hasher }
+    }
+}
+
+impl<'a, H: sha2::Digest> Write for HashingWriter<'a, H> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.hasher.update(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
The changes introduced to this PR guarantees that when re-serializing `TcbInfo` using `serde_json`, we can get the raw form to match exactly as the form signed by Intel.